### PR TITLE
Bump runtime to 3.26 as well

### DIFF
--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Evince",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.24",
+    "runtime-version": "3.26",
     "branch": "stable",
     "sdk": "org.gnome.Sdk",
     "command": "evince",


### PR DESCRIPTION
I assume that the runtime being on 3.24 where the rest of the dependencies are 3.26 is just an oversight rather than anything particularly special.