### PR TITLE
Update poppler to 0.71.0

### DIFF
--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -81,7 +81,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz",
+                    "url": "https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz",
                     "sha256": "1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012"
                 }
             ]
@@ -99,8 +99,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://poppler.freedesktop.org/poppler-0.68.0.tar.xz",
-                    "sha256": "f90d04f0fb8df6923ecb0f106ae866cf9f8761bb537ddac64dfb5322763d0e58"
+                    "url": "https://poppler.freedesktop.org/poppler-0.71.0.tar.xz",
+                    "sha256": "badbecd2dddf63352fd85ec08a9c2ed122fdadacf2a34fcb4cc227c4d01f2cf9"
                 }
             ]
         },
@@ -126,7 +126,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/gnome/sources/libgxps/0.3/libgxps-0.3.0.tar.xz",
+                    "url": "https://download.gnome.org/sources/libgxps/0.3/libgxps-0.3.0.tar.xz",
                     "sha256": "412b1343bd31fee41f7204c47514d34c563ae34dafa4cc710897366bd6cd0fae"
                 }
             ]


### PR DESCRIPTION
New versions contain couple security fixes. see https://poppler.freedesktop.org/releases.html

Also use https for download sources.