### PR TITLE
Require Flatpak >= 0.11.6

### DIFF
--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -20,7 +20,9 @@
         "--talk-name=org.gtk.vfs.*",
         "--talk-name=org.gnome.SessionManager",
         "--own-name=org.gnome.evince",
-        "--own-name=org.gnome.evince.Daemon"
+        "--own-name=org.gnome.evince.Daemon",
+        /* Commit 8f428fd7683765dd706da06e9f376d3732ce5c0c required for dbus service exports matching own name above */
+        "--require-version=0.11.6"
     ],
     "build-options": {
         "env": {


### PR DESCRIPTION
This commit is required: https://github.com/flatpak/flatpak/commit/8f428fd7683765dd706da06e9f376d3732ce5c0c

See also: https://gitlab.gnome.org/GNOME/evince/merge_requests/98

Fixes: https://github.com/flathub/org.gnome.Evince/pull/26 (Well safely handles)