### PR TITLE
Remove trailing comma

### DIFF
--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -174,7 +174,7 @@
                     "url": "https://download.gnome.org/sources/evince/3.34/evince-3.34.0.tar.xz",
                     "sha256": "3297d16d2d1426f72ea090749ba72424d08eb133fbe4101e52a0b84999ad2a51",
                     "git-init" : true
-                },
+                }
             ]
         }
     ]


### PR DESCRIPTION
```
Can't parse 'org.gnome.Evince.json': <data>:177:18: Parse error: unexpected character `,', expected character `]'
```