### PR TITLE
Add access to pulseaudio sound server

### DIFF
--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -9,6 +9,7 @@
         "--share=ipc",
         "--socket=x11",
         "--socket=wayland",
+        "--socket=pulseaudio",
         "--filesystem=host",
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
         "--metadata=X-DConf=migrate-path=/org/gnome/evince/",


### PR DESCRIPTION
This PR add --socket=pulseaudio to flatpak. It permits Evince flatpak to play sound in the case of a PDF having an external audio file to play. Thanks to @nbenitez for the suggestion.