### PR TITLE
Disable boost and remove splash

### DIFF
--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -82,8 +82,7 @@
                 "-DCMAKE_INSTALL_INCLUDEDIR=/app/include",
                 "-DBUILD_GTK_TESTS=OFF",
                 "-DBUILD_CPP_TESTS=OFF",
-                "-DENABLE_SPLASH=OFF",
-                "-DENABLE_UTILS=OFF",
+                "-DENABLE_BOOST=OFF",
                 "-DENABLE_CPP=OFF",
                 "-DENABLE_GOBJECT_INTROSPECTION=OFF",
                 "-DENABLE_LIBOPENJPEG=openjpeg2"


### PR DESCRIPTION
* There is no more option to disable Splash.
* The build requires libboosts by default which is not available
  in the CI.