### PR TITLE
fix: Unsecure permissions. Remove filesystem=host.

### DIFF
--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -10,7 +10,12 @@
         "--socket=x11",
         "--socket=wayland",
         "--socket=pulseaudio",
-        "--filesystem=host",
+        /* For external hot-plugging devices such USB Flash drives, HDD, SSD */
+        "--filesystem=/media:ro",
+        "--filesystem=/run/media:ro",
+        /* For old distros with outdated portals which could have some issues and annoyances for users */
+        "--filesystem=xdg-documents",
+        "--filesystem=xdg-download",
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
         "--metadata=X-DConf=migrate-path=/org/gnome/evince/",
         "--env=GDK_PIXBUF_MODULE_FILE=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache",


### PR DESCRIPTION
Please. There is no need for disabling sandbox entirely. See discussion: https://pagure.io/fedora-workstation/issue/244#comment-751477