### PR TITLE
Change socket to fallback-X11 to fix "Unsafe" warning

### DIFF
--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -7,7 +7,7 @@
     "command": "evince",
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
         "--filesystem=host",


### PR DESCRIPTION
Using `--socket=x11` results in GNOME Software showing the app as "Unsafe. Uses a legacy windowing system." Changing this to `--socket=fallback-x11` lets app run on Wayland, but can use X11 if Wayland not available