### PR TITLE
Update evince to 42.3

### DIFF
--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -208,7 +208,11 @@
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/evince/42/evince-42.3.tar.xz",
                     "sha256": "49aecf845c946c96db17ba89d75c8002c5ae8963f504a9b0626d12675914645e",
-                    "git-init": true
+                    "git-init": true,
+                    "x-checker-data" : {
+                         "type" : "gnome",
+                         "name" : "evince"
+                     }
                 }
             ]
         }

--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -191,7 +191,11 @@
                 {
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/gnome-desktop/42/gnome-desktop-42.1.tar.xz",
-                    "sha256": "2433ab606d244c3524de5b812094db8a670fb11ed9ff7180c2d021ae1fc9fc05"
+                    "sha256": "2433ab606d244c3524de5b812094db8a670fb11ed9ff7180c2d021ae1fc9fc05",
+                    "x-checker-data" : {
+                         "type" : "gnome",
+                         "name" : "gnome-desktop"
+                     }
                 }
             ]
         },

--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -206,8 +206,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/evince/42/evince-42.1.tar.xz",
-                    "sha256": "b24767bb3d5103b4e35b0e15cf033dbe2488f88700cdd882d22a43adeec2e80a",
+                    "url": "https://download.gnome.org/sources/evince/42/evince-42.3.tar.xz",
+                    "sha256": "49aecf845c946c96db17ba89d75c8002c5ae8963f504a9b0626d12675914645e",
                     "git-init": true
                 }
             ]

--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -171,8 +171,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://libarchive.org/downloads/libarchive-3.6.0.tar.xz",
-                    "sha256": "df283917799cb88659a5b33c0a598f04352d61936abcd8a48fe7b64e74950de7"
+                    "url": "https://libarchive.org/downloads/libarchive-3.6.1.tar.xz",
+                    "sha256": "5a411aceb978f43e626f0c2d1812ddd8807b645ed892453acabd532376c148e6"
                 }
             ]
         },

--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -190,8 +190,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-desktop/42/gnome-desktop-42.0.tar.xz",
-                    "sha256": "f3caa293a5e86f6ccad18f817273db1c67061e680d79d839aa8a7528e5bb26d6"
+                    "url": "https://download.gnome.org/sources/gnome-desktop/42/gnome-desktop-42.1.tar.xz",
+                    "sha256": "2433ab606d244c3524de5b812094db8a670fb11ed9ff7180c2d021ae1fc9fc05"
                 }
             ]
         },


### PR DESCRIPTION
Update:
- evince to 42.3 and add external checker
- gnome-desktop to 42.1 and external checker
- libarchive to 3.6.1
