### PR TITLE
Replace host permission with home permission

### DIFF
--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -10,7 +10,10 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
-        "--filesystem=host",
+        "--filesystem=home:ro",
+        /* For external hot-plugging devices such USB Flash drives, HDD, SSD */
+        "--filesystem=/media:ro",
+        "--filesystem=/run/media:ro",
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
         "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gtk.vfs.*",


### PR DESCRIPTION
We add escaped for media devices as USB or removable disks.

This is a less ambitious version of https://github.com/flathub/org.gnome.Evince/pull/61. 