### PR TITLE
Remove access to whole filesystem

### DIFF
--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -10,7 +10,6 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
-        "--filesystem=host",
         "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
         "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gtk.vfs.*",


### PR DESCRIPTION
Minimizing permissions is always a good idea.
Why do you now need access to all files? Is not the idea that exploits or so in a PDF viewer could be mitigated/not have such a bad effect if it does not have access to all files?

> The filesystem=host permission got copied from upstream/Flathub https://github.com/flathub/org.gnome.Evince/blob/master/org.gnome.Evince.json#L13
> It seems that revoking that permission doesn't cause any problem with the app's main functionality.

https://bugzilla.redhat.com/show_bug.cgi?id=2098179

Ref upstream also did not explain why/how this permission would be needed: https://gitlab.gnome.org/GNOME/evince/-/issues/1810

Fixes https://github.com/flathub/org.gnome.Evince/issues/76