### PR TITLE
Fix wrong downgrades of libgxps

### DIFF
--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -154,7 +154,7 @@
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "libgxps",
-                        /* TODO: remove when https://github.com/flathub/flatpak-external-data-checker/issues/338 is fixed */
+                        "// TODO": "remove when https://github.com/flathub/flatpak-external-data-checker/issues/338 is fixed",
                         "stable-only": false
                     }
                 }

--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -154,9 +154,8 @@
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "libgxps",
-                        "versions": {
-                            ">": "0.3.0"
-                        }
+                        /* TODO: remove when https://github.com/flathub/flatpak-external-data-checker/issues/338 is fixed */
+                        "stable-only": false
                     }
                 }
             ]

--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -153,7 +153,10 @@
                     "sha256": "6d27867256a35ccf9b69253eb2a88a32baca3b97d5f4ef7f82e3667fa435251c",
                     "x-checker-data": {
                         "type": "gnome",
-                        "name": "libgxps"
+                        "name": "libgxps",
+                        "versions": {
+                            ">": "0.3.0"
+                        }
                     }
                 }
             ]


### PR DESCRIPTION
This should stop the extra "upgrade" of `libgxps`, as found in #115, #114 and olders.