### PR TITLE
Remove org.gnome.SettingsDaemon.MediaKeys

### DIFF
--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -13,7 +13,6 @@
         "--filesystem=home:ro",
         "--filesystem=/media:ro",
         "--filesystem=/run/media:ro",
-        "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
         "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gtk.vfs.*",
         "--talk-name=org.gnome.SessionManager",


### PR DESCRIPTION
This interface was removed for GNOME 42.

See https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/merge_requests/268

cc: @hadess 