### PR TITLE
Update runtime to 48>50 and more

### DIFF
--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,0 +1,58 @@
+From 0f7bc76709d49dff2febaa76340b4b37f48cbcca Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sat, 21 Mar 2026 22:10:33 +0300
+Subject: [PATCH] Fix appdata paper cuts
+
+### Fix empty translation error
+
+> E:org.gnome.Evince.metainfo.xml:tag-empty:283 The mentioned tag is empty,
+> which is highly likely not intended as it should have content.
+
+### Fix appdata paper cuts
+
+- Fix developer ID
+- Fix homepage error
+---
+ data/org.gnome.Evince.metainfo.xml.in | 6 +++---
+ po/hi.po                              | 2 --
+ 2 files changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/data/org.gnome.Evince.metainfo.xml.in b/data/org.gnome.Evince.metainfo.xml.in
+index 08242c8..6f27ffa 100644
+--- a/data/org.gnome.Evince.metainfo.xml.in
++++ b/data/org.gnome.Evince.metainfo.xml.in
+@@ -39,15 +39,15 @@
+     <caption>Advanced highlighting and annotation</caption>
+     </screenshot>
+   </screenshots>
+-  <url type="homepage">https://apps.gnome.org/Evince</url>
++  <url type="homepage">https://gitlab.gnome.org/GNOME/evince</url>
+   <url type="bugtracker">https://gitlab.gnome.org/GNOME/evince/-/issues/</url>
+   <url type="translate">https://l10n.gnome.org/module/evince/</url>
+   <url type="contribute">https://welcome.gnome.org/app/Evince</url>
+   <url type="donation">https://www.gnome.org/donate/</url>
+   <url type="vcs-browser">https://gitlab.gnome.org/GNOME/evince/</url>
+   <project_group>GNOME</project_group>
+-  <developer id="org.gnome">
+-    <name>The GNOME Project</name>
++  <developer id="org.gnome.gitlab.evince">
++    <name>The Evince Developers</name>
+   </developer>
+   <update_contact>https://discourse.gnome.org/tag/evince</update_contact>
+   <kudos>
+diff --git a/po/hi.po b/po/hi.po
+index 6cb22cb..3e4b385 100644
+--- a/po/hi.po
++++ b/po/hi.po
+@@ -411,8 +411,6 @@ msgid ""
+ "Evince supports documents in: PDF, PS, EPS, XPS, DjVu, TIFF, DVI (with "
+ "SyncTeX), and Comic Books archives (CBR, CBT, CBZ, CB7)."
+ msgstr ""
+-"एविंस निम्नलिखित दस्तावेज़ प्रारूप का समर्थन करता है: PDF, PS, EPS, XPS, DjVu, TIFF, "
+-"DVI (SyncTeX के साथ) और कॉमिक बुक अभिलेखागार (CBR, CBT, CBZ & CB7)।"
+ 
+ #: data/org.gnome.Evince.metainfo.xml.in:35
+ msgid "A clear, simple UI"
+--
+libgit2 1.7.2
+

--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -1,7 +1,7 @@
 {
     "id": "org.gnome.Evince",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "50",
     "default-branch": "stable",
     "sdk": "org.gnome.Sdk",
     "command": "evince",
@@ -29,39 +29,12 @@
     "cleanup": [
         "/include",
         "/lib/pkgconfig",
-        "/share/pkgconfig",
-        "/share/aclocal",
-        "/man",
         "/share/man",
-        "/share/gtk-doc",
-        "/share/vala",
+        "/share/pkgconfig",
         "*.la",
         "*.a"
     ],
     "modules": [
-        {
-            "name": "webp-pixbuf-loader",
-            "buildsystem": "meson",
-            "build-options": {
-                "env": {
-                    "GDK_PIXBUF_MODULEDIR": "/app/lib/evince/gdk-pixbuf/2.10.0/"
-                }
-            },
-            "config-opts": [
-                "-Dgdk_pixbuf_moduledir=/app/lib/evince/gdk-pixbuf/2.10.0/"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/aruiz/webp-pixbuf-loader.git",
-                    "commit": "52232e4ba282b2fed68e8fcb4b5d45ed0eaa4ed3",
-                    "tag": "0.2.7"
-                }
-            ],
-            "post-install": [
-                "gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULEDIR/loaders.cache"
-            ]
-        },
         {
             "name": "popplerdata",
             "no-autogen": true,
@@ -102,8 +75,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://poppler.freedesktop.org/poppler-26.02.0.tar.xz",
-                    "sha256": "dded8621f7b2f695c91063aab1558691c8418374cd583501e89ed39487e7ab77",
+                    "url": "https://poppler.freedesktop.org/poppler-26.03.0.tar.xz",
+                    "sha256": "8b3c5e2a9f2ab4c3ec5029f28af1b433c6b71f0d1e7b3997aa561cf1c0ca4ebe",
                     "x-checker-data": {
                         "is-important": true,
                         "type": "anitya",
@@ -174,8 +147,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gspell/1.14/gspell-1.14.2.tar.xz",
-                    "sha256": "4ec7e5accc9013281bacd6bbc00006be733818b81ba3fe332c1e876c7e1e1477",
+                    "url": "https://download.gnome.org/sources/gspell/1.14/gspell-1.14.3.tar.xz",
+                    "sha256": "e8b39c67556f75495362952f81ca241b5a3c17c75960b77fc93fa702c612a5a4",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "gspell"
@@ -197,8 +170,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-desktop/44/gnome-desktop-44.4.tar.xz",
-                    "sha256": "1d8cb9c6a328eb689b0c1269cf53834cc84d851d7e71970cdabba82706b44984",
+                    "url": "https://download.gnome.org/sources/gnome-desktop/44/gnome-desktop-44.5.tar.xz",
+                    "sha256": "20e0995a6e3a03e8c1026c5a27bc3f45e69ffcc392ad743dcab6107a541d232f",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "gnome-desktop"

--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -75,8 +75,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://poppler.freedesktop.org/poppler-26.03.0.tar.xz",
-                    "sha256": "8b3c5e2a9f2ab4c3ec5029f28af1b433c6b71f0d1e7b3997aa561cf1c0ca4ebe",
+                    "url": "https://poppler.freedesktop.org/poppler-26.04.0.tar.xz",
+                    "sha256": "b0955163114af96bc0106f68cb24daf973a629462453d8b82775f81b0d4e0693",
                     "x-checker-data": {
                         "is-important": true,
                         "type": "anitya",

--- a/org.gnome.Evince.json
+++ b/org.gnome.Evince.json
@@ -198,6 +198,10 @@
                         "type": "gnome",
                         "name": "evince"
                     }
+                },
+                {
+                    "type": "patch",
+                    "path": "fix-appdata.patch"
                 }
             ]
         }


### PR DESCRIPTION
- Update runtime to 50
- Use webp-pixbuf-module from runtime
- Update dependencies using FEDC
- Drop ineffective cleanup commands
- Fix appdata paper cuts
- Fix empty translation error

> E:org.gnome.Evince.metainfo.xml:tag-empty:283 The mentioned tag is empty,
> which is highly likely not intended as it should have content.